### PR TITLE
Possible solutions from CGS

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -21,7 +21,7 @@ check_queries <- function(var, GCAM_version = 'v7.0') {
   queryItems <- var_fun_map[var_fun_map$name == var, "queries"][[1]]
 
   it = 1; allOk = TRUE
-  while (!is.na(queryItems) & it <= as.numeric(length(queryItems)) & allOk) {
+  while (!(sum(is.na(queryItems))) & it <= as.numeric(length(queryItems)) & allOk) {
     qi <- var_fun_map[var_fun_map$name == var, "queries"][[1]][it]
     allOk = qi %in% rgcam::listQueries(prj)
     it = it + 1

--- a/R/functions.R
+++ b/R/functions.R
@@ -259,13 +259,19 @@ handle_warning <- function(mapping_name1, mapping_name2 = NULL, query_name = NUL
 #' @param ... Additional arguments passed to `dplyr::left_join()`.
 #' @return A data frame resulting from the left join. If any rows in `left_df` do not have matching keys in `right_df`, an error is thrown.
 #' @export
-left_join_strict <- function(left_df, right_df, by = NULL, by_message = by, mapping = "", ...) {
+left_join_strict <- function(left_df, right_df, by = NULL, by_message = by, mapping = "", ignr = ignore.global, ...) {
   # Perform the left join
   result <- dplyr::left_join(left_df, right_df, by = by, ...)
 
   # Identify unmatched rows (rows with NA in any of the columns from right_df)
   unmatched <- result %>%
     dplyr::filter(dplyr::if_any(-one_of(names(left_df)), is.na))
+
+  # Ignore any unmatched rows which have names (in any column) specified as fine to be ignored
+  if (!is.null(ignr)) {
+    unmatched <- unmatched %>%
+    dplyr::filter(!(dplyr::if_any(.cols = everything(), ~ grepl(paste(ignr, collapse = "|"), .))))
+  }
 
   # Check if there are any unmatched rows
   if (nrow(unmatched) > 0) {

--- a/R/main.R
+++ b/R/main.R
@@ -534,6 +534,7 @@ available_variables <- function(print = TRUE, GCAM_version = "v7.0") {
 #' @param scenarios Names of the scenarios to consider. Defaults to all scenarios in the project or database.
 #' @param final_year Final year of the data. Defaults to 2100. Note: `final_year` must be at least 2025 and must align with available 5-year intervals, such as 2025, 2030, 2035, 2040, etc.
 #' @param desired_variables Variables to include in the report. Defaults to 'All'. Specify a vector for specific variables. To view available options, run `available_variables()`. Note: Global variables like "Emissions" will only account for selected variables. E.g., if you select "Emissions" and "Emissions|CO2", "Emissions" will only account for "Emissions|CO2", and will not account for other variables such as "Emissions|CH4" or "Emissions|NH3".
+#' @param ignore Policy names introduced by the user to ignore during gcamreport processing of physical quantities, since otherwise they will be flagged as names missing from mapping files and cause an error. Note: Currently having one of the specified name patterns in any column of the query results, such as sector, subsector, input, etc. will cause the error to be disregarded.
 #' @param desired_regions Regions to include in the report. Defaults to 'All'. Specify a vector for specific regions. To view available options, run `available_regions()`. Note: The dataset will include only the specified regions, which will make up "World".
 #' @param desired_continents Continent/region groups to include in the report. Defaults to 'All'. Specify a vector for specific groups. To view available options, run `available_continents()`. Note: The dataset will include only the specified groups, which will make up "World".
 #' @param save_output If `TRUE` (default), saves reporting data in CSV and XLSX formats. If `FALSE`, data is not saved. If 'CSV' or 'XLSX', data will be saved only in the specified format.
@@ -547,7 +548,7 @@ available_variables <- function(print = TRUE, GCAM_version = "v7.0") {
 #' @return Saves RData, CSV, and XLSX files with standardized variables, launches the user interface, and saves the GCAM project file if created.
 #' @export
 generate_report <- function(db_path = NULL, db_name = NULL, prj_name, scenarios = NULL, final_year = 2100,
-                            desired_variables = "All", desired_regions = "All", desired_continents = "All",
+                            desired_variables = "All", ignore = NULL, desired_regions = "All", desired_continents = "All",
                             save_output = TRUE, output_file = NULL, launch_ui = TRUE,
                             GCAM_version = 'v7.0', GWP_version = 'AR5',
                             queries_general_file = NULL, queries_nonCO2_file = NULL) {
@@ -749,6 +750,9 @@ generate_report <- function(db_path = NULL, db_name = NULL, prj_name, scenarios 
         FALSE, required
       ))
   }
+
+  # make ignore a global variable
+  ignore.global <<- ignore
 
   rlang::inform("Loading data, performing checks, and saving output...")
 


### PR DESCRIPTION
Hi all, here are two different small commits, the first to address an error that I got when running it, where the logical test within the while command had "too many elements", and the second to allow users to specify names of policies that they introduced in add-on GCAM input files to be ignored in left_join_strict.

The first could use verification to make sure that it functions as was intended. For the second we can discuss about it to see if this is a good enough solution to an issue that gets in the way of CGS (and probably other organizations) using gcamreport, which is where policy names such as "bio-ceiling" which are made by add-on files for the GCAM run get pulled by the query, such as the primary energy query, and then stop gcamreport, since those rows are not matched in the mapping file. We use many different policy names and they change for each project, so it would be cumbersome to add every one to each mapping file. Let us know what you think!