### PR TITLE
Include non-2020 base year in reporting

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -741,7 +741,7 @@ generate_report <- function(db_path = NULL, db_name = NULL, prj_name, scenarios 
       "'final_year' is set to '%s' but must be at least 2025. Please select a valid year: '%s.\n",
       final_year.global, paste(available_final_year, collapse = ", ")))
   }
-  # check that final_year is availabe (5-year interval)
+  # check that final_year is available (5-year interval)
   if (!final_year.global %in% available_final_year) {
     stop(sprintf(
       "'final_year' is set to '%s' but must align with the available years in your project data. Please select a valid year: '%s.\n",
@@ -750,7 +750,7 @@ generate_report <- function(db_path = NULL, db_name = NULL, prj_name, scenarios 
 
 
   # final reporting columns
-  reporting_columns.global <<- append(c("Model", "Scenario", "Region", "Variable", "Unit"), as.character(seq(2005, final_year.global, by = 5)))
+  reporting_columns.global <<- append(c("Model", "Scenario", "Region", "Variable", "Unit"), as.character(sort(union(available_reporting_years, seq(2005, final_year.global, by = 5)))))
 
   # desired variables to have in the report
   template_internal_variable <- get(paste('template',GCAM_version,sep='_'), envir = asNamespace("gcamreport"))[['Internal_variable']]


### PR DESCRIPTION
Hi Claudia and team,

At least for checking out the recent scenarios we want to include 2021 in the reporting. 

I feel that the most straightforward way to do this would be to have the reporting columns be all of the years in the `available_reporting_years`. However, in this commit I did the union of those with `2005:5:2100`, since `available_reporting_years `doesn't include 2020 (which we still want to report, especially once we have GCAM producing results for it again in a little while). The reason that 2020 isn't in there, is due to this line:
`if (base_year == 2021) years_in_prj <- setdiff(years_in_prj, 2020`
I think that that should probably be changed somehow, at least when GCAM starts returning valid results for 2020 again. 

Feel free to do any modifications to these lines. The only intent was to get 2021 back in the reporting somehow. 