### PR TITLE
Pass GCAM_version to conv_EJ_GW in capacity functions

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -5356,7 +5356,7 @@ get_elec_capacity_tot <- function(GCAM_version = "v7.1") {
       left_join_strict(elec_cf %>%
                          dplyr::select(-cf.rgn), by = c("region", "technology", "vintage")) %>%
       dplyr::mutate(EJ = value) %>%
-      conv_EJ_GW() %>%
+      conv_EJ_GW(GCAM_version = GCAM_version) %>%
       dplyr::group_by(scenario, region, technology, year) %>%
       dplyr::summarise(value = sum(gw, na.rm = T)) %>%
       dplyr::ungroup() %>%
@@ -5436,7 +5436,7 @@ get_elec_capacity_add_tmp <- function(GCAM_version = 'v7.1') {
       dplyr::distinct() %>%
       # use average annual additions
       dplyr::mutate(EJ = value / 5) %>%
-      conv_EJ_GW() %>%
+      conv_EJ_GW(GCAM_version = GCAM_version) %>%
       dplyr::group_by(scenario, region, technology, year) %>% #
       dplyr::summarise(GW = sum(gw, na.rm = T), EJ = sum(EJ, na.rm = T)) %>%
       dplyr::ungroup()
@@ -5495,7 +5495,7 @@ get_refliq_capacity_add_tmp <- function(GCAM_version = 'v7.1') {
       filter_variables() %>%
       # use average annual additions
       dplyr::mutate(EJ = value / 5) %>%
-      conv_EJ_GW() %>%
+      conv_EJ_GW(GCAM_version = GCAM_version) %>%
       dplyr::group_by(scenario, region, technology, year) %>% #
       dplyr::summarise(GW = sum(gw, na.rm = T), EJ = sum(EJ, na.rm = T)) %>%
       dplyr::ungroup()
@@ -5554,7 +5554,7 @@ get_hydrogen_capacity_add_tmp <- function(GCAM_version = 'v7.1') {
       filter_variables() %>%
       # use average annual additions
       dplyr::mutate(EJ = value / 5) %>%
-      conv_EJ_GW() %>%
+      conv_EJ_GW(GCAM_version = GCAM_version) %>%
       dplyr::group_by(scenario, region, technology, year) %>% #
       dplyr::summarise(GW = sum(gw, na.rm = T), EJ = sum(EJ, na.rm = T)) %>%
       dplyr::ungroup()


### PR DESCRIPTION
## Problem

`conv_EJ_GW()` is defined with a hard-coded default `GCAM_version = "v7.1"`:

```r
conv_EJ_GW <- function(data, cf, EJ, GCAM_version = "v7.1") { ... }
```

Inside the capacity functions it is called **without** passing `GCAM_version`:

- `get_elec_capacity_tot()`
- `get_elec_capacity_add_tmp()`
- `get_refliq_capacity_add_tmp()`
- `get_hydrogen_capacity_add_tmp()`

All four of these functions receive a `GCAM_version` argument, but they do not
forward it. So even when a report is generated with `GCAM_version = "v7.0"`
(or `"v7.2"`), the inner `conv_EJ_GW()` falls back to the `"v7.1"` default and
tries to load `convert_v7.1` via `get(..., envir = asNamespace("gcamreport"))`.

If `convert_v7.1` was not generated locally (e.g. only the v7.0 data files were
built), the run fails with:

```
Error in `dplyr::mutate()`:
i In argument: `gw = `/`(...)`.
Caused by error in `get()`:
! object 'convert_v7.1' not found
```

The numerical impact is small because the `convert_*` constants
(`hr_per_yr`, `EJ_to_GWh`, ...) are the same across versions, but the
missing-object error blocks any non-v7.1 capacity run.

## Fix

Forward the caller's `GCAM_version` at each of the four call sites:

```r
conv_EJ_GW(GCAM_version = GCAM_version)
```

For a v7.1 run this is identical to the previous behaviour (same default). For
v7.0 / v7.2 runs it now resolves the correct `convert_<version>` object instead
of crashing.