### PR TITLE
Deduplicate cf_iea rows against cf_gcam/cf_rgn in get_elec_cf_tmp

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -5361,16 +5361,27 @@ get_elec_cf_tmp <- function(GCAM_version = 'v8.2') {
     handle_warning(mapping_name1 = 'A23.globaltech_capacity_factor', mapping_name2 = 'L223.StubTechCapFactor_elec')
   }
 
-  elec_cf <-
+  elec_cf_main <-
     tmp1 %>%
     # first, replace regional cf for wind and solar
     dplyr::left_join( # left_join already checked
       tmp2,
       by = c("technology", "vintage", "region")
     ) %>%
-    dplyr::mutate(cf = replace(cf, !is.na(cf.rgn), cf.rgn[!is.na(cf.rgn)])) %>%
-    # second, use iea capacity consistent cf for existing vintage
-    dplyr::bind_rows(cf_iea_filteredReg) %>%
+    dplyr::mutate(cf = replace(cf, !is.na(cf.rgn), cf.rgn[!is.na(cf.rgn)]))
+
+  # second, use iea capacity consistent cf only for vintages that do not
+  # already have a cf_gcam / cf_rgn value. Without this anti_join the iea
+  # rows duplicate the (technology, region, vintage) keys above, so the
+  # approx_fun() interpolation below averages the two values instead of
+  # keeping the intended cf_gcam / cf_rgn value (which over-estimates
+  # fossil capacity and shifts renewable capacity factors).
+  elec_cf <-
+    elec_cf_main %>%
+    dplyr::bind_rows(
+      cf_iea_filteredReg %>%
+        dplyr::anti_join(elec_cf_main, by = c("technology", "region", "vintage"))
+    ) %>%
     tidyr::complete(tidyr::nesting(technology, region), vintage = sort(years_in_prj[years_in_prj >= 1990])) %>%
     dplyr::group_by(technology, region) %>%
     dplyr::mutate(cf = approx_fun(vintage, cf, rule = 2)) %>%


### PR DESCRIPTION
## Problem

In `get_elec_cf_tmp()` (R/functions.R), the comment says the IEA capacity factors are meant
for existing vintages only:

```r
# second, use iea capacity consistent cf for existing vintage
dplyr::bind_rows(cf_iea_filteredReg) %>%
```

But `cf_iea_filteredReg` also has rows for 2025+ vintages. So after
`bind_rows()`, the same `(technology, region, vintage)` appears twice: once
with the `cf_gcam` / `cf_rgn` value and once with the IEA value. The
`approx_fun()` interpolation then averages the two.

As a result, the final capacity factor is wrong for every technology that has
both values. For example, wind with `cf_rgn = 0.23` and IEA cf = 0.15 ends up
at about 0.19. Coal with `cf_gcam = 0.85` and IEA cf = 0.55 ends up at about
0.70, which over-estimates coal capacity.

## Fix

Add `anti_join()` so the IEA rows are used only for vintages that
`cf_gcam` / `cf_rgn` do not cover.